### PR TITLE
Update ssh_login.sh, fix connection issue if use ssh private/public key

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -513,8 +513,12 @@ class Terminal(object):
     def ssh_login(self, user, server, password, port):
         active_terminal = self.application.window.get_focus()
         if active_terminal and isinstance(active_terminal, TerminalWrapper):
-            active_terminal.feed_child(
-                "%s %s %s %s %s\n" % (os.path.join(get_parent_dir(__file__), "ssh_login.sh"), user, server, password, port))
+            command = "%s %s %s\n" % (os.path.join(get_parent_dir(__file__), "ssh_login.sh"), user, server)
+            if len(password):
+                command = "EXP_SSH_PASS=\"%s\" %s" % (password, command)
+            if len(port):
+                command = "EXP_SSH_PORT=\"%s\" %s" % (port, command)
+            active_terminal.feed_child(command)
         
     def keybind_change(self, key_value, new_key):
         for terminal in get_match_children(self.application.window, TerminalWrapper):

--- a/src/ssh_login.sh
+++ b/src/ssh_login.sh
@@ -1,28 +1,48 @@
-#!/usr/bin/expect -f  
-set user [lindex $argv 0 ]
-set server [lindex $argv 1 ]
-set password [lindex $argv 2 ]
-set port [lindex $argv 3 ]
-set timeout 10
-#puts $user
-#puts $server
-#puts $password
-#puts $port
-if { ![string compare $port "" ] == 0 } { spawn ssh $user@$server -p $port } else { spawn ssh $user@$server };
+#! /usr/bin/expect -f
 
-if { ![string compare $password ""] == 0 } {
-    #puts "PASSWORD GIVEN!"
+## All possible interactive messages:
+# Are you sure you want to continue connecting (yes/no)?
+# password:
+# Enter passphrase for key
+
+## Main
+if {$argc < 2} {
+    set scriptname [lindex [split $argv0 "/"] end]
+    send_user "Usage: $scriptname <user> <host>\n"
+    send_user "Environment variables: EXP_SSH_PASS, EXP_SSH_PORT, EXP_SSH_OPT\n"
+    exit 1
+}
+
+# Setup variables
+set timeout 10
+set user [lindex $argv 0]
+set host [lindex $argv 1]
+set ssh_cmd "ssh"
+set ssh_opt "$user@$host"
+
+set password ""
+if {[info exists env(EXP_SSH_PASS)]} {
+    set password $env(EXP_SSH_PASS)
+}
+
+if {[info exists env(EXP_SSH_PORT)]} {
+    set ssh_opt "$ssh_opt -p $env(EXP_SSH_PORT)"
+}
+
+if {[info exists env(EXP_SSH_OPT)]} {
+    set ssh_opt "$ssh_opt $env(EXP_SSH_OPT)"
+}
+
+# Spawn and expect
+eval spawn $ssh_cmd $ssh_opt
+if {[string length $password]} {
     expect {
-        "*yes/no" { send "yes\r"; exp_continue}
-        "*password:" { send "$password\r" }
-        exp_continue
-    }
-} else {
-    expect {
-        "*yes/no" { send "yes\r"; exp_continue }
-        exp_continue
+        timeout {send_user "ssh connection time out, please operate manually\n"}
+        -nocase "(yes/no)\\?" {send "yes\r"; exp_continue}
+        -nocase -re "password:|enter passphrase for key" {
+            send "$password\r"
+        }
     }
 }
 
-#puts "interacting"
 interact


### PR DESCRIPTION
更新 ssh_login.sh，将 `password` 作为可选参数，若用户没有设置密码，则认为不需要进行 expect 操作，若登录过程中需要输入密码，则由用户自己处理，若不需要输入密码，则将成功登录。与之前相比唯一的区别是，若用户没有设置密码，第一次登录时的 yes/no 必须要手动处理。
